### PR TITLE
feat: width & height in string percentage

### DIFF
--- a/__tests__/src/height.test.js
+++ b/__tests__/src/height.test.js
@@ -1,0 +1,25 @@
+import apply from "../../dist/core/apply";
+
+test("fixed 100 height namespace", () => {
+  expect(apply("h-100")).toEqual({ height: 100 });
+});
+
+test("fixed 75 height namespace", () => {
+  expect(apply("h-75")).toEqual({ height: 75 });
+});
+
+test("fixed 50 height namespace", () => {
+  expect(apply("h-50")).toEqual({ height: 50 });
+});
+
+test("100% height namespace", () => {
+  expect(apply("h%100")).toEqual({ height: "100%" });
+});
+
+test("75% height namespace", () => {
+  expect(apply("h%75")).toEqual({ height: "75%" });
+});
+
+test("50% height namespace", () => {
+  expect(apply("h%50")).toEqual({ height: "50%" });
+});

--- a/__tests__/src/width.test.js
+++ b/__tests__/src/width.test.js
@@ -1,0 +1,25 @@
+import apply from "../../dist/core/apply";
+
+test("fixed 100 width namespace", () => {
+  expect(apply("w-100")).toEqual({ width: 100 });
+});
+
+test("fixed 75 width namespace", () => {
+  expect(apply("w-75")).toEqual({ width: 75 });
+});
+
+test("fixed 50 width namespace", () => {
+  expect(apply("w-50")).toEqual({ width: 50 });
+});
+
+test("100% width namespace", () => {
+  expect(apply("w%100")).toEqual({ width: "100%" });
+});
+
+test("75% width namespace", () => {
+  expect(apply("w%75")).toEqual({ width: "75%" });
+});
+
+test("50% width namespace", () => {
+  expect(apply("w%50")).toEqual({ width: "50%" });
+});

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -20,6 +20,12 @@ const apply = (args: string): object => {
     // auto generate fixed width size
     instanceStyle.fixedHeightSize(syntax)
 
+    // auto generate percentage width
+    instanceStyle.percentWidth(syntax)
+
+    // auto generate percentage height
+    instanceStyle.percentHeight(syntax)
+
     // Check if there's coloring opacity
     instanceStyle.colorOpacity(syntax)
 

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -91,6 +91,30 @@ export default class Instance {
   }
 
   /**
+   * Auto generate width in $ (string)
+   * @param data
+   */
+  percentWidth(data: string) {
+    if (/(\bw\b\%[0-9]+)/.test(data)) {
+      this.updateObject({
+        width: data.replace("w%", "") + "%"
+      })
+    }
+  }
+
+  /**
+   * Auto generate height in $ (string)
+   * @param data
+   */
+   percentHeight(data: string) {
+    if (/(\bh\b\%[0-9]+)/.test(data)) {
+      this.updateObject({
+        height: data.replace("h%", "") + "%"
+      })
+    }
+  }
+
+  /**
    * Checking if there's a color opacity
    * @param syntax
    */

--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -51,6 +51,12 @@ export default class OsmiProvider {
           // auto generate fixed width size
           instanceStyle.fixedHeightSize(syntax)
 
+          // auto generate percentage width
+          instanceStyle.percentWidth(syntax)
+
+          // auto generate percentage height
+          instanceStyle.percentHeight(syntax)
+
           // Check if there's coloring opacity
           instanceStyle.colorOpacity(syntax)
 
@@ -93,6 +99,12 @@ export default class OsmiProvider {
 
       // auto generate fixed width size
       instanceStyle.fixedHeightSize(syntax)
+
+      // auto generate percentage width
+      instanceStyle.percentWidth(syntax)
+
+      // auto generate percentage height
+      instanceStyle.percentHeight(syntax)
 
       // Check if there's coloring opacity
       instanceStyle.colorOpacity(syntax)


### PR DESCRIPTION
Adding support for percentage width & height in string. Issue #21 

## Example Width
### Input
```jsx
apply("w%50")
```

### Output
```jsx
{
  width: "50%"
}
```

## Example Height
### Input
```jsx
apply("h%50")
```

### Output
```jsx
{
  height: "50%"
}
```