### PR TITLE
feat: adding max & min for width & height

### DIFF
--- a/__tests__/src/max-size.test.js
+++ b/__tests__/src/max-size.test.js
@@ -1,0 +1,25 @@
+import apply from '../../dist/core/apply';
+
+test('max-w-50 namespace', () => {
+  expect(apply('max-w-50')).toEqual({ maxWidth: 50 })
+})
+
+test('max-w-75 namespace', () => {
+  expect(apply('max-w-75')).toEqual({ maxWidth: 75 })
+})
+
+test('max-w-100 namespace', () => {
+  expect(apply('max-w-100')).toEqual({ maxWidth: 100 })
+})
+
+test('max-h-50 namespace', () => {
+  expect(apply('max-h-50')).toEqual({ maxHeight: 50 })
+})
+
+test('max-h-75 namespace', () => {
+  expect(apply('max-h-75')).toEqual({ maxHeight: 75 })
+})
+
+test('max-h-100 namespace', () => {
+  expect(apply('max-h-100')).toEqual({ maxHeight: 100 })
+})

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -17,6 +17,18 @@ import { BackgroundDark, BorderDark, TextDark } from "../processor/processor.typ
 import { onAction } from "mobx-state-tree"
 import { appearanceHook } from "./appearance"
 
+type WidthSize = {
+  maxWidth?: number,
+  minWidth?: number,
+  width?: number
+}
+
+type HeightSize = {
+  maxHeight?: number,
+  minHeight?: number,
+  height?: number
+}
+
 export default class Instance {
   _predefined: object | any
   _theme?: string
@@ -73,7 +85,7 @@ export default class Instance {
   fixedWidthSize(data: string) {
     if(/(\bw\b\-[0-9]+)/.test(data)) {
       // Check wether it's max width, min width or width
-      const _nextObject = data.includes("max-w-") ? {
+      const _nextObject: WidthSize = data.includes("max-w-") ? {
         maxWidth: Number(data.replace("max-w-", ""))
       } : data.includes("min-w-") ? {
         minWidth: Number(data.replace("min-w-", ""))
@@ -92,7 +104,7 @@ export default class Instance {
   fixedHeightSize(data: string) {
     if (/(\bh\b\-[0-9]+)/.test(data)) {
       // Check wether it's max height, min height or height
-      const _nextObject = data.includes("max-h-") ? {
+      const _nextObject: HeightSize = data.includes("max-h-") ? {
         maxHeight: Number(data.replace("max-h-", ""))
       } : data.includes("min-h-") ? {
         minHeight: Number(data.replace("min-h-", ""))

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -72,9 +72,16 @@ export default class Instance {
    */
   fixedWidthSize(data: string) {
     if(/(\bw\b\-[0-9]+)/.test(data)) {
-      this.updateObject({
+      // Check wether it's max width, min width or width
+      const _nextObject = data.includes("max-w-") ? {
+        maxWidth: Number(data.replace("max-w-", ""))
+      } : data.includes("min-w-") ? {
+        minWidth: Number(data.replace("min-w-", ""))
+      } : {
         width: Number(data.replace("w-", ""))
-      })
+      }
+
+      this.updateObject(_nextObject)
     }
   }
 
@@ -84,9 +91,16 @@ export default class Instance {
    */
   fixedHeightSize(data: string) {
     if (/(\bh\b\-[0-9]+)/.test(data)) {
-      this.updateObject({
+      // Check wether it's max height, min height or height
+      const _nextObject = data.includes("max-h-") ? {
+        maxHeight: Number(data.replace("max-h-", ""))
+      } : data.includes("min-h-") ? {
+        minHeight: Number(data.replace("min-h-", ""))
+      } : {
         height: Number(data.replace("h-", ""))
-      })
+      }
+
+      this.updateObject(_nextObject)
     }
   }
 


### PR DESCRIPTION
## Max & Min Width
Currently, we only adding max & min-width with a fixed size. Any feedback for responsive based on `Dimension` or using string percentage are welcome

### Usage
```jsx
apply("min-w-30 max-w-150")
```

### Output
```jsx
{
  minWidth: 30,
  maxWidth: 150
}
```

## Max & Min Height
Currently, we only adding max & min-height with a fixed size. Any feedback for responsive based on `Dimension` or using string percentage are welcome

### Usage
```jsx
apply("min-h-30 max-h-150")
```

### Output
```jsx
{
  minHeight: 30,
  maxHeight: 150
}
```