### PR TITLE
feat: transform position processor

### DIFF
--- a/__tests__/src/translate.test.js
+++ b/__tests__/src/translate.test.js
@@ -1,0 +1,49 @@
+import apply from "../../dist/core/apply";
+
+test("translate-x-50 namespace", () => {
+  expect(apply("translate-x-50")).toEqual({ transform: [{ translateX: 50 }] })
+});
+
+test("translate-x-75 namespace", () => {
+  expect(apply("translate-x-75")).toEqual({ transform: [{ translateX: 75 }] })
+});
+
+test("translate-x-100 namespace", () => {
+  expect(apply("translate-x-100")).toEqual({ transform: [{ translateX: 100 }] })
+});
+
+test("translate-y-50 namespace", () => {
+  expect(apply("translate-y-50")).toEqual({ transform: [{ translateY: 50 }] })
+});
+
+test("translate-y-75 namespace", () => {
+  expect(apply("translate-y-75")).toEqual({ transform: [{ translateY: 75 }] })
+});
+
+test("translate-y-100 namespace", () => {
+  expect(apply("translate-y-100")).toEqual({ transform: [{ translateY: 100 }] })
+});
+
+test("-translate-x-50 namespace", () => {
+  expect(apply("-translate-x-50")).toEqual({ transform: [{ translateX: -50 }] })
+});
+
+test("-translate-x-75 namespace", () => {
+  expect(apply("-translate-x-75")).toEqual({ transform: [{ translateX: -75 }] })
+});
+
+test("-translate-x-100 namespace", () => {
+  expect(apply("-translate-x-100")).toEqual({ transform: [{ translateX: -100 }] })
+});
+
+test("-translate-y-50 namespace", () => {
+  expect(apply("-translate-y-50")).toEqual({ transform: [{ translateY: -50 }] })
+});
+
+test("-translate-y-75 namespace", () => {
+  expect(apply("-translate-y-75")).toEqual({ transform: [{ translateY: -75 }] })
+});
+
+test("-translate-y-100 namespace", () => {
+  expect(apply("-translate-y-100")).toEqual({ transform: [{ translateY: -100 }] })
+});

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -26,6 +26,9 @@ const apply = (args: string): object => {
     // auto generate percentage height
     instanceStyle.percentHeight(syntax)
 
+    // auto generate transform position
+    instanceStyle.transformTranslate(syntax)
+
     // Check if there's coloring opacity
     instanceStyle.colorOpacity(syntax)
 

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -14,7 +14,6 @@ import opacityProcessor from "../processor/opacityProcessor"
 import { BackgroundDark, BorderDark, TextDark } from "../processor/processor.type"
 
 // Appearance Hook
-import { onAction } from "mobx-state-tree"
 import { appearanceHook } from "./appearance"
 
 type WidthSize = {
@@ -146,25 +145,22 @@ export default class Instance {
    */
    transformTranslate(syntax: string) {
     if (/(-translate|translate)-(x|y)-([0-9]{1,3}$)/.test(syntax)) {
-      let _updatedObject: object = {}
       const extractTranslate: string[] = syntax.split("-")
       const isNegative: boolean = syntax.includes("-translate")
       const lastIndex: number = extractTranslate.length - 1
       const value: number = isNegative ? Number(-extractTranslate[lastIndex]) : Number(extractTranslate[lastIndex])
 
       if (extractTranslate.includes("x")) {
-        _updatedObject = {
+        this.updateObject({
           transform: [{ translateX: value }]
-        }
+        })
       }
 
       if (extractTranslate.includes("y")) {
-        _updatedObject = {
+        this.updateObject({
           transform: [{ translateY: value }]
-        }
+        })
       }
-
-      this.updateObject(_updatedObject)
     }
   }
 

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -141,6 +141,34 @@ export default class Instance {
   }
 
   /**
+   * Auto generate translate X or Y position
+   * @param syntax styles syntax
+   */
+   transformTranslate(syntax: string) {
+    if (/(-translate|translate)-(x|y)-([0-9]{1,3}$)/.test(syntax)) {
+      let _updatedObject: object = {}
+      const extractTranslate: string[] = syntax.split("-")
+      const isNegative: boolean = syntax.includes("-translate")
+      const lastIndex: number = extractTranslate.length - 1
+      const value: number = isNegative ? Number(-extractTranslate[lastIndex]) : Number(extractTranslate[lastIndex])
+
+      if (extractTranslate.includes("x")) {
+        _updatedObject = {
+          transform: [{ translateX: value }]
+        }
+      }
+
+      if (extractTranslate.includes("y")) {
+        _updatedObject = {
+          transform: [{ translateY: value }]
+        }
+      }
+
+      this.updateObject(_updatedObject)
+    }
+  }
+
+  /**
    * Checking if there's a color opacity
    * @param syntax
    */

--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -57,6 +57,9 @@ export default class OsmiProvider {
           // auto generate percentage height
           instanceStyle.percentHeight(syntax)
 
+          // auto generate transform position
+          instanceStyle.transformTranslate(syntax)
+
           // Check if there's coloring opacity
           instanceStyle.colorOpacity(syntax)
 


### PR DESCRIPTION
## Transform Position Processor
Add transform position processor to auto-generate *Translate X* and *Translate Y*. Feature request from #30 

### Usage
```jsx
// Example 1
apply("translate-x-50")

// Example 2
apply("translate-y-50")

// Example 3
apply("-translate-x-50")

// Example 4
apply("-translate-y-50")
```

### Output
```jsx
// Example 1
{
  transform: [{ translateX: 50 }]
}

// Example 2
{
  transform: [{ translateY: 50 }]
}

// Example 3
{
  transform: [{ translateX: -50 }]
}

// Example 4
{
  transform: [{ translateY: -50 }]
}
```