### PR TITLE
feat: add transform rotate

### DIFF
--- a/__tests__/src/transform-rotate.test.js
+++ b/__tests__/src/transform-rotate.test.js
@@ -1,0 +1,97 @@
+import apply from "../../dist/core/apply";
+
+test("rotate-50 namespace", () => {
+  expect(apply("rotate-50")).toEqual({ transform: [{ rotate: "50deg" }] })
+});
+
+test("rotate-75 namespace", () => {
+  expect(apply("rotate-75")).toEqual({ transform: [{ rotate: "75deg" }] })
+});
+
+test("rotate-100 namespace", () => {
+  expect(apply("rotate-100")).toEqual({ transform: [{ rotate: "100deg" }] })
+});
+
+test("rotate-x-50 namespace", () => {
+  expect(apply("rotate-x-50")).toEqual({ transform: [{ rotateX: "50deg" }] })
+});
+
+test("rotate-x-75 namespace", () => {
+  expect(apply("rotate-x-75")).toEqual({ transform: [{ rotateX: "75deg" }] })
+});
+
+test("rotate-x-100 namespace", () => {
+  expect(apply("rotate-x-100")).toEqual({ transform: [{ rotateX: "100deg" }] })
+});
+
+test("rotate-z-50 namespace", () => {
+  expect(apply("rotate-z-50")).toEqual({ transform: [{ rotateZ: "50deg" }] })
+});
+
+test("rotate-z-75 namespace", () => {
+  expect(apply("rotate-z-75")).toEqual({ transform: [{ rotateZ: "75deg" }] })
+});
+
+test("rotate-z-100 namespace", () => {
+  expect(apply("rotate-z-100")).toEqual({ transform: [{ rotateZ: "100deg" }] })
+});
+
+test("rotate-y-50 namespace", () => {
+  expect(apply("rotate-y-50")).toEqual({ transform: [{ rotateY: "50deg" }] })
+});
+
+test("rotate-y-75 namespace", () => {
+  expect(apply("rotate-y-75")).toEqual({ transform: [{ rotateY: "75deg" }] })
+});
+
+test("rotate-y-100 namespace", () => {
+  expect(apply("rotate-y-100")).toEqual({ transform: [{ rotateY: "100deg" }] })
+});
+
+test("-rotate-50 namespace", () => {
+  expect(apply("-rotate-50")).toEqual({ transform: [{ rotate: "-50deg" }] })
+});
+
+test("-rotate-75 namespace", () => {
+  expect(apply("-rotate-75")).toEqual({ transform: [{ rotate: "-75deg" }] })
+});
+
+test("-rotate-100 namespace", () => {
+  expect(apply("-rotate-100")).toEqual({ transform: [{ rotate: "-100deg" }] })
+});
+
+test("-rotate-x-50 namespace", () => {
+  expect(apply("-rotate-x-50")).toEqual({ transform: [{ rotateX: "-50deg" }] })
+});
+
+test("-rotate-x-75 namespace", () => {
+  expect(apply("-rotate-x-75")).toEqual({ transform: [{ rotateX: "-75deg" }] })
+});
+
+test("-rotate-x-100 namespace", () => {
+  expect(apply("-rotate-x-100")).toEqual({ transform: [{ rotateX: "-100deg" }] })
+});
+
+test("-rotate-y-50 namespace", () => {
+  expect(apply("-rotate-y-50")).toEqual({ transform: [{ rotateY: "-50deg" }] })
+});
+
+test("-rotate-y-75 namespace", () => {
+  expect(apply("-rotate-y-75")).toEqual({ transform: [{ rotateY: "-75deg" }] })
+});
+
+test("-rotate-y-100 namespace", () => {
+  expect(apply("-rotate-y-100")).toEqual({ transform: [{ rotateY: "-100deg" }] })
+});
+
+test("-rotate-z-50 namespace", () => {
+  expect(apply("-rotate-z-50")).toEqual({ transform: [{ rotateZ: "-50deg" }] })
+});
+
+test("-rotate-z-75 namespace", () => {
+  expect(apply("-rotate-z-75")).toEqual({ transform: [{ rotateZ: "-75deg" }] })
+});
+
+test("-rotate-z-100 namespace", () => {
+  expect(apply("-rotate-z-100")).toEqual({ transform: [{ rotateZ: "-100deg" }] })
+});

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -35,6 +35,9 @@ const apply = (args: string): object => {
     // auto generate transform skew
     instanceStyle.transformSkew(syntax)
 
+    // auto generate transform rotate
+    instanceStyle.transformRotate(syntax)
+
     // Check if there's coloring opacity
     instanceStyle.colorOpacity(syntax)
 

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -194,6 +194,43 @@ export default class Instance {
       }
     }
   }
+
+  /**
+   * Auto generate rotate X,Y or Both position
+   * @param syntax styles syntax
+   */
+  transformRotate(syntax: string) {
+    if (/(-rotate|rotate)-(x|y|z)-([0-9]{1,3}$)/.test(syntax) || /(-rotate|rotate)-([0-9]{1,3}$)/.test(syntax)) {
+      const extractRotate: string[] = syntax.split("-")
+      const isNegative: boolean = syntax.includes("-rotate")
+      const lastIndex: number = extractRotate.length - 1
+      const value: number = isNegative ? Number(-extractRotate[lastIndex]) : Number(extractRotate[lastIndex])
+
+      if (extractRotate.includes("x")) {
+        this.updateObject({
+          transform: [{ rotateX: `${value}deg` }]
+        })
+      }
+
+      if (extractRotate.includes("y")) {
+        this.updateObject({
+          transform: [{ rotateY: `${value}deg` }]
+        })
+      }
+
+      if (extractRotate.includes("z")) {
+        this.updateObject({
+          transform: [{ rotateZ: `${value}deg` }]
+        })
+      }
+
+      if (!extractRotate.includes("x") && !extractRotate.includes("y") && !extractRotate.includes("z")) {
+        this.updateObject({
+          transform: [{ rotate: `${value}deg` }]
+        })
+      }
+    }
+  }
   
   /**
    * Auto generate translate X or Y position

--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -115,8 +115,14 @@ export default class OsmiProvider {
       // auto generate transform position
       instanceStyle.transformTranslate(syntax)
 
+      // auto generate transform scale
+      instanceStyle.transformScale(syntax)
+
       // auto generate transform skew
       instanceStyle.transformSkew(syntax)
+
+      // auto generate transform rotate
+      instanceStyle.transformRotate(syntax)
 
       // Check if there's coloring opacity
       instanceStyle.colorOpacity(syntax)


### PR DESCRIPTION
## Transform Rotate Processor
Add transform rotate processor to auto-generate *Rotate X*, *Rotate Y*, *Rotate Z* or *Rotate* for both. Feature request from #30 

### Usage
```jsx
// Example 1
apply("rotate-50")

// Example 2
apply("-rotate-50")

// Example 3
apply("rotate-x-50")

// Example 4
apply("rotate-y-50")

// Example 5
apply("rotate-z-50")

// Example 6
apply("-rotate-x-50")

// Example 7
apply("-rotate-y-50")

// Example 8
apply("-rotate-z-50")
```

### Output
```jsx
// Example 1
{
  transform: [{ rotate: "50deg" }]
}

// Example 2
{
  transform: [{ rotate: "-50deg" }]
}

// Example 3
{
  transform: [{ rotateX: "50deg" }]
}

// Example 4
{
  transform: [{ rotateY: "50deg" }]
}

// Example 5
{
  transform: [{ rotateZ: "50deg" }]
}

// Example 6
{
  transform: [{ rotateX: "-50deg" }]
}

// Example 7
{
  transform: [{ rotateY: "-50deg" }]
}

// Example 8
{
  transform: [{ rotateZ: "-50deg" }]
}
```