### PR TITLE
feat: add percentage size

### DIFF
--- a/__tests__/src/percent-size.test.js
+++ b/__tests__/src/percent-size.test.js
@@ -1,0 +1,29 @@
+import apply from "../../dist/core/apply";
+
+test("min-w namespace", () => {
+  expect(apply("min-w%50")).toEqual({ minWidth: "50%"})
+})
+
+test("w namespace", () => {
+  expect(apply("w%50")).toEqual({ width: "50%"})
+})
+
+test("max-w namespace", () => {
+  expect(apply("max-w%50")).toEqual({ maxWidth: "50%"})
+})
+
+test("min-h namespace", () => {
+  expect(apply("min-h%50")).toEqual({ minHeight: "50%"})
+})
+
+test("h namespace", () => {
+  expect(apply("h%50")).toEqual({ height: "50%"})
+})
+
+test("max-h namespace", () => {
+  expect(apply("max-h%50")).toEqual({ maxHeight: "50%"})
+})
+
+test("text namespace", () => {
+  expect(apply("text%50")).toEqual({ fontSize: "50%"})
+})

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -14,17 +14,14 @@ const apply = (args: string): object => {
     // check if width & size using responsive method or not
     instanceStyle.responsiveSize(syntax)
 
+    // auto generate percentage size
+    instanceStyle.percentSize(syntax)
+
     // auto generate fixed width size
     instanceStyle.fixedWidthSize(syntax)
 
     // auto generate fixed width size
     instanceStyle.fixedHeightSize(syntax)
-
-    // auto generate percentage width
-    instanceStyle.percentWidth(syntax)
-
-    // auto generate percentage height
-    instanceStyle.percentHeight(syntax)
 
     // auto generate transform position
     instanceStyle.transformTranslate(syntax)

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -4,6 +4,9 @@ import map from "../predefined/map"
 // responsive module
 import { convertResponsive } from "../lib/responsive"
 
+// percentage
+import { convertPercentage } from "../lib/percentage"
+
 // import dark theme processor
 import darkThemeProcessor from "../processor/darkThemeProcessor"
 
@@ -67,8 +70,8 @@ export default class Instance {
   }
 
   /**
-   * Check if the width & height are
-   * responsive or not
+   * Check if the ["min-w", "w", "max-w", "min-h", "h", "max-h"]
+   * are responsive or not
    * @param data
    */
   responsiveSize(data: string) {
@@ -116,26 +119,12 @@ export default class Instance {
   }
 
   /**
-   * Auto generate width in $ (string)
+   * Check if the size style are using percentage or not.
    * @param data
    */
-  percentWidth(data: string) {
-    if (/(\bw\b\%[0-9]+)/.test(data)) {
-      this.updateObject({
-        width: data.replace("w%", "") + "%"
-      })
-    }
-  }
-
-  /**
-   * Auto generate height in $ (string)
-   * @param data
-   */
-   percentHeight(data: string) {
-    if (/(\bh\b\%[0-9]+)/.test(data)) {
-      this.updateObject({
-        height: data.replace("h%", "") + "%"
-      })
+   percentSize(data: string) {
+    if (data.includes("%")) {
+      this.updateObject(convertPercentage(data.split("%")))
     }
   }
 

--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -45,17 +45,14 @@ export default class OsmiProvider {
           // check if width & size using responsive method or not
           instanceStyle.responsiveSize(syntax)
 
+          // auto generate percentage size
+          instanceStyle.percentSize(syntax)
+
           // auto generate fixed width size
           instanceStyle.fixedWidthSize(syntax)
 
           // auto generate fixed width size
           instanceStyle.fixedHeightSize(syntax)
-
-          // auto generate percentage width
-          instanceStyle.percentWidth(syntax)
-
-          // auto generate percentage height
-          instanceStyle.percentHeight(syntax)
 
           // auto generate transform position
           instanceStyle.transformTranslate(syntax)
@@ -106,17 +103,14 @@ export default class OsmiProvider {
       // check if width & size using responsive method or not
       instanceStyle.responsiveSize(syntax)
 
+      // auto generate percentage size
+      instanceStyle.percentSize(syntax)
+
       // auto generate fixed width size
       instanceStyle.fixedWidthSize(syntax)
 
       // auto generate fixed width size
       instanceStyle.fixedHeightSize(syntax)
-
-      // auto generate percentage width
-      instanceStyle.percentWidth(syntax)
-
-      // auto generate percentage height
-      instanceStyle.percentHeight(syntax)
 
       // auto generate transform position
       instanceStyle.transformTranslate(syntax)

--- a/src/lib/percentage.ts
+++ b/src/lib/percentage.ts
@@ -1,0 +1,47 @@
+/**
+ * Detect osmi style and Convert it into Width / Heihgt / Font Size as percentage
+ * @param {array} array from split string "%" with type and value
+ * @return {object} object style width / height / font size
+ */
+export const convertPercentage = ([type, value]: string[]): object | undefined => {
+  switch(type) {
+    case "w":
+      return {
+        width: `${value}%`
+      }
+
+    case "h":
+      return {
+        height: `${value}%`
+      }
+
+    case "text":
+      return {
+        fontSize: `${value}%`
+      }
+
+    case "min-w":
+      return {
+        minWidth: `${value}%`
+      }
+
+    case "min-h":
+      return {
+        minHeight: `${value}%`
+      }
+
+    case "max-w":
+      return {
+        maxWidth: `${value}%`
+      }
+
+    case "max-h":
+      return {
+        maxHeight: `${value}%`
+      }
+
+    default:
+      console.warn(`OsmiCSX Percentage: Undefined type of ${type}}`)
+      return undefined
+  }
+}

--- a/src/lib/responsive.ts
+++ b/src/lib/responsive.ts
@@ -39,7 +39,7 @@ const scaleHeight = (heightPercent: number): number => {
 /**
  * Detect osmi style and Convert it into Width / Heihgt / Font Size
  * @param {array} array from split string "/" with type and value
- * @return {object} object style width / height /font size
+ * @return {object} object style width / height / font size
  */
 const convertResponsive = ([type, value]: string[]): object | undefined => {
   switch(type) {
@@ -56,6 +56,26 @@ const convertResponsive = ([type, value]: string[]): object | undefined => {
     case "text":
       return {
         fontSize: scaleWidth(Number(value))
+      }
+
+    case "min-w":
+      return {
+        minWidth: scaleWidth(Number(value))
+      }
+
+    case "min-h":
+      return {
+        minHeight: scaleHeight(Number(value))
+      }
+
+    case "max-w":
+      return {
+        maxWidth: scaleWidth(Number(value))
+      }
+
+    case "max-h":
+      return {
+        maxHeight: scaleHeight(Number(value))
       }
 
     default:

--- a/src/predefined/text-responsive.ts
+++ b/src/predefined/text-responsive.ts
@@ -1,16 +1,17 @@
-import { scaleHeight } from "../lib/responsive";
+import { scaleWidth } from "../lib/responsive";
 
 const textResponsive = {
-  "text-r-xs": { fontSize: scaleHeight(1.42) },
-  "text-r-sm": { fontSize: scaleHeight(1.64) },
-  "text-r-base": { fontSize: scaleHeight(1.84) },
-  "text-r-lg": { fontSize: scaleHeight(2.14) },
-  "text-r-xl": { fontSize: scaleHeight(2.32) },
-  "text-r-2xl": { fontSize: scaleHeight(2.6)},
-  "text-r-3xl": { fontSize: scaleHeight(2.8) },
-  "text-r-4xl": { fontSize: scaleHeight(3.05) },
-  "text-r-5xl": { fontSize: scaleHeight(3.25) },
-  "text-r-6xl": { fontSize: scaleHeight(3.55) }
+  "text-r-xxs": { fontSize: scaleWidth(2.67) },
+  "text-r-xs": { fontSize: scaleWidth(3.2) },
+  "text-r-sm": { fontSize: scaleWidth(3.73) },
+  "text-r-base": { fontSize: scaleWidth(4.27) },
+  "text-r-lg": { fontSize: scaleWidth(4.8) },
+  "text-r-xl": { fontSize: scaleWidth(5.33) },
+  "text-r-2xl": { fontSize: scaleWidth(5.87)},
+  "text-r-3xl": { fontSize: scaleWidth(6.4) },
+  "text-r-4xl": { fontSize: scaleWidth(6.93) },
+  "text-r-5xl": { fontSize: scaleWidth(7.47) },
+  "text-r-6xl": { fontSize: scaleWidth(8) }
 }
 
 export default textResponsive

--- a/src/predefined/text-size.json
+++ b/src/predefined/text-size.json
@@ -1,4 +1,5 @@
 {
+  "text-xxs": { "fontSize": 10 },
   "text-xs": { "fontSize": 12 },
   "text-sm": { "fontSize": 14 },
   "text-base": { "fontSize": 16 },


### PR DESCRIPTION
## Percentage Size
Adding percentage size processor to auto-generate size based on % string. Size support for this processor:
- minWidth
- width
- maxWidth
- minHeight
- height
- maxHeight
- fontSize

### Example Input
```jsx
apply("min-w%50")
```
```jsx
apply("w%50")
```
```jsx
apply("max-w%50")
```
```jsx
apply("min-h%50")
```
```jsx
apply("h%50")
```
```jsx
apply("max-h%50")
```

### Example Output
```jsx
{ minWidth: "50%" }
```
```jsx
{ width: "50%" }
```
```jsx
{ maxWidth: "50%" }
```
```jsx
{ minHeight: "50%" }
```
```jsx
{ height: "50%" }
```
```jsx
{ maxHeight: "50%" }
```
