### PR TITLE
fix: connect type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmicsx",
-  "version": "0.7.0-alpha.4",
+  "version": "0.7.0-alpha.5",
   "description": "An utility style framework for React Native.",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmicsx",
-  "version": "0.7.0-alpha.3",
+  "version": "0.7.0-alpha.4",
   "description": "An utility style framework for React Native.",
   "type": "module",
   "license": "MIT",

--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -60,10 +60,11 @@ export default function providerApp(theme: CustomThemeType) {
     style: T | NamedInputStyles<T>
   ): NamedOuputStyles<T> {
     let objStyle: any = {};
-    const instanceStyle = initProvider.initInstance();
 
     const _runProcessing = () => {
       Object.entries(style).forEach(([key, value]) => {
+        const instanceStyle = initProvider.initInstance();
+
         value.split(" ").map((syntax: string) => {
           // check if width & size using responsive method or not
           instanceStyle.responsiveSize(syntax);


### PR DESCRIPTION
## Fix dynamic type for output of `connect()` method
Now you can defined output style for each item inside `connect()` method.

### Example
```jsx
import {ViewStyle, TextStyle} from 'react-native';
import {connect} from './OsmiProvider';

type AppStyle = {
  container: ViewStyle;
  title: TextStyle;
};

export default connect<AppStyle>({
  container: 'flex bg-white dark:bg-gray-900 items-center justify-center',
  title: 'font-bold text-black',
});

```