### PR TITLE
Relax peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "node": ">=8.9.0"
   },
   "peerDependencies": {
-    "@types/react": "^18.x.x",
-    "@types/react-native": "^0.68.x"
+    "@types/react": ">=18.0.0",
+    "@types/react-native": ">=0.68.0"
   }
 }

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -2,85 +2,93 @@ import { Instance } from "./instance";
 import type { NamedStyles, OsmiContextInstance } from "../types/osmi.types";
 
 export const applyHelper =
-  <T extends NamedStyles<T> | NamedStyles<any>>(...args: string[]) =>
-  (themeContext: OsmiContextInstance | null) => {
-    const outputStyles: object[] = [];
+  <T extends NamedStyles<T> | NamedStyles<any>>(
+    ...args: (boolean | string)[]
+  ) =>
+    (themeContext: OsmiContextInstance | null) => {
+      const outputStyles: object[] = [];
 
-    // Get syntax from each args
-    for (let i = 0; i < args.length; i++) {
-      // Init instance
-      const instanceStyle = new Instance(themeContext?.theme);
+      // Get syntax from each args
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] !== false) {
+          // Init instance
+          const instanceStyle = new Instance(themeContext?.theme);
 
-      // Get syntax list from each args
-      const argStyle = args[i];
-      const syntaxList = argStyle.split(" ");
-      const sortedSyntax = [
-        ...syntaxList.filter(
-          (item) =>
-            !item.includes("dark:") &&
-            !item.includes("notch:") &&
-            !item.includes("android:") &&
-            !item.includes("ios:")
-        ),
-        ...syntaxList.filter((item) => item.includes("android:")),
-        ...syntaxList.filter((item) => item.includes("ios:")),
-        ...syntaxList.filter((item) => item.includes("notch:")),
-        ...syntaxList.filter((item) => item.includes("dark:")),
-      ];
+          // Get syntax list from each args
+          const argStyle = args[i] as string;
+          const syntaxList = argStyle.split(" ");
+          const sortedSyntax = [
+            ...syntaxList.filter(
+              (item) =>
+                !item.includes("dark:") &&
+                !item.includes("notch:") &&
+                !item.includes("android:") &&
+                !item.includes("ios:")
+            ),
+            ...syntaxList.filter((item) => item.includes("android:")),
+            ...syntaxList.filter((item) => item.includes("ios:")),
+            ...syntaxList.filter((item) => item.includes("notch:")),
+            ...syntaxList.filter((item) => item.includes("dark:")),
+          ];
 
-      sortedSyntax.map((syntax: string) => {
-        // Only allow string syntax
-        if (typeof syntax !== "string") {
-          throw new Error("Invalid styling syntax.");
+          sortedSyntax.map((syntax: string) => {
+            // Only allow string syntax
+            if (typeof syntax !== "string") {
+              throw new Error("Invalid styling syntax.");
+            }
+
+            // Check for android platform only
+            instanceStyle.android(syntax);
+
+            // Check for ios platform only
+            instanceStyle.ios(syntax);
+
+            // Check if there's notch or not.
+            instanceStyle.notch(syntax);
+
+            if (
+              !syntax.includes("android:") &&
+              !syntax.includes("ios:") &&
+              !syntax.includes("notch:")
+            ) {
+              // check if width & size using responsive method or not
+              instanceStyle.responsiveSize(syntax);
+
+              // auto generate percentage size
+              instanceStyle.percentSize(syntax);
+
+              // auto generate fixed width size
+              instanceStyle.fixedWidthSize(syntax);
+
+              // auto generate fixed width size
+              instanceStyle.fixedHeightSize(syntax);
+
+              // auto generate transform position
+              instanceStyle.transformTranslate(syntax);
+
+              // auto generate transform scale
+              instanceStyle.transformScale(syntax);
+
+              // auto generate transform skew
+              instanceStyle.transformSkew(syntax);
+
+              // auto generate transform rotate
+              instanceStyle.transformRotate(syntax);
+
+              // Check if there's coloring opacity
+              instanceStyle.colorOpacity(syntax);
+
+              // Check if there's any dark theme
+              instanceStyle.darkTheme(syntax, themeContext?.mode ?? "system");
+
+              // Generate from pre-defined styles
+              instanceStyle.predefinedStyles(syntax);
+            }
+          });
+
+          outputStyles.push(instanceStyle.getOutputStyle());
         }
+      }
 
-        // Check for android platform only
-        instanceStyle.android(syntax);
-
-        // Check for ios platform only
-        instanceStyle.ios(syntax);
-
-        // Check if there's notch or not.
-        instanceStyle.notch(syntax);
-
-        if (!syntax.includes("android:") && !syntax.includes("ios:") && !syntax.includes("notch:")) {
-          // check if width & size using responsive method or not
-          instanceStyle.responsiveSize(syntax);
-
-          // auto generate percentage size
-          instanceStyle.percentSize(syntax);
-
-          // auto generate fixed width size
-          instanceStyle.fixedWidthSize(syntax);
-
-          // auto generate fixed width size
-          instanceStyle.fixedHeightSize(syntax);
-
-          // auto generate transform position
-          instanceStyle.transformTranslate(syntax);
-
-          // auto generate transform scale
-          instanceStyle.transformScale(syntax);
-
-          // auto generate transform skew
-          instanceStyle.transformSkew(syntax);
-
-          // auto generate transform rotate
-          instanceStyle.transformRotate(syntax);
-
-          // Check if there's coloring opacity
-          instanceStyle.colorOpacity(syntax);
-
-          // Check if there's any dark theme
-          instanceStyle.darkTheme(syntax, themeContext?.mode ?? "system");
-
-          // Generate from pre-defined styles
-          instanceStyle.predefinedStyles(syntax);
-        }
-      });
-
-      outputStyles.push(instanceStyle.getOutputStyle());
-    }
-
-    return outputStyles as any[];
-  };
+      return outputStyles as any[];
+    };

--- a/src/core/hooks.tsx
+++ b/src/core/hooks.tsx
@@ -12,7 +12,9 @@ export const useStyles = (): ApplyInstance => {
   }
 
   const apply = useCallback(
-    <T extends NamedStyles<T> | NamedStyles<any>>(...args: string[]) => {
+    <T extends NamedStyles<T> | NamedStyles<any>>(
+      ...args: (boolean | string)[]
+    ) => {
       return applyHelper(...args)(themeContext);
     },
     [themeContext]

--- a/src/types/osmi.types.ts
+++ b/src/types/osmi.types.ts
@@ -20,7 +20,7 @@ export interface OsmiContextInstance {
 
 export interface ApplyInstance {
   apply: <T extends NamedStyles<T> | NamedStyles<any>>(
-    ...args: string[]
+    ...args: (string | boolean)[]
   ) => any;
   colors: (
     ...args: string[]


### PR DESCRIPTION
This allows users with newer versions of packages listed in peerDependencies to install without the need for `--legacy-peer-deps` flag.

Here's an example of this error before the relaxing of peerDependencies:

```shell
$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: undefined@undefined
npm ERR! Found: @types/react-native@0.71.3
npm ERR! node_modules/@types/react-native
npm ERR!   dev @types/react-native@"^0.71.3" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @types/react-native@"^0.68.x" from osmicsx@1.1.2
npm ERR! node_modules/osmicsx
npm ERR!   osmicsx@"^1.1.2" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```